### PR TITLE
Upgraded to redis-py 5.0.1 - required for Python 3.12 support

### DIFF
--- a/redisu/ru101/uc02-inventory-control/inventory.py
+++ b/redisu/ru101/uc02-inventory-control/inventory.py
@@ -22,7 +22,7 @@ def create_customers(cust_array):
   """Create customer keys from the array of passed customer details"""
   for cust in cust_array:
     c_key = keynamehelper.create_key_name("customer", cust['id'])
-    redis.hmset(c_key, cust)
+    redis.hset(c_key, mapping = cust)
 
 events = [{'sku': "123-ABC-723",
            'name': "Men's 100m Final",
@@ -67,7 +67,7 @@ for number of available tickets, price and ticket tier."""
     if price != None:
       event['price:' + tier] = price
     e_key = keynamehelper.create_key_name("event", event['sku'])
-    redis.hmset(e_key, event)
+    redis.hset(e_key, mapping = event)
     redis.sadd(e_set_key, event['sku'])
 
 # Part One - Check availability and Purchase
@@ -86,7 +86,7 @@ def check_availability_and_purchase(customer, event_sku, qty, tier="General"):
                   'tier': tier, 'qty': qty, 'cost': qty * price,
                   'event_sku': event_sku, 'ts': int(time.time())}
       so_key = keynamehelper.create_key_name("sales_order", order_id)
-      p.hmset(so_key, purchase)
+      p.hset(so_key, mapping = purchase)
       p.execute()
     else:
       print("Insufficient inventory, have {}, requested {}".format(available,
@@ -233,9 +233,9 @@ def create_expired_reservation(event_sku, tier="General"):
            'qty:UZ1EL0': 7, 'tier:UZ1EL0': tier, 'ts:UZ1EL0': int(cur_t - 30)
           }
   k = keynamehelper.create_key_name("ticket_hold", event_sku)
-  redis.hmset(k, holds)
+  redis.hset(k, mapping = holds)
   k = keynamehelper.create_key_name("event", event_sku)
-  redis.hmset(k, tickets)
+  redis.hset(k, mapping = tickets)
 
 def expire_reservation(event_sku, cutoff_time_secs=30):
   """ Check if any reservation has exceeded the cutoff time. If any have, then

--- a/redisu/ru101/uc04-notifications/notify.py
+++ b/redisu/ru101/uc04-notifications/notify.py
@@ -14,7 +14,7 @@ redis = None
 def create_event(event_sku):
   """Create the event key from the provided details."""
   e_key = keynamehelper.create_key_name("event", event_sku)
-  redis.hmset(e_key, {'sku': event_sku})
+  redis.hset(e_key, mapping = {'sku': event_sku})
 
 def purchase(event_sku):
   """Simple purchase function, that pushes the sales order for publishing"""
@@ -29,7 +29,7 @@ def purchase(event_sku):
 def post_purchases(order_id, s_order):
   """Publish purchases to the queue."""
   so_key = keynamehelper.create_key_name("sales_order", order_id)
-  redis.hmset(so_key, s_order)
+  redis.hset(so_key, mapping = s_order)
   notify_key = keynamehelper.create_key_name("sales_order_notify")
   redis.publish(notify_key, order_id)
   notify_key = keynamehelper.create_key_name("sales_order_notify",

--- a/redisu/ru101/uc04-notifications/notify.py
+++ b/redisu/ru101/uc04-notifications/notify.py
@@ -125,7 +125,7 @@ def test_pub_sub():
                                   args=(stop_event,)))
 
   for i in range(len(threads)):
-    threads[i].setDaemon(True)
+    threads[i].daemon = True
     threads[i].start()
 
   for i in range(15):
@@ -178,7 +178,7 @@ def test_patterned_subs():
                                   args=("sales_order_notify",)))
 
   for i in range(len(threads)):
-    threads[i].setDaemon(True)
+    threads[i].daemon = True
     threads[i].start()
 
   events = ["Mens Boxing", "Womens 4x400",

--- a/redisu/ru101/uc05-finding-venues/finding_venues.py
+++ b/redisu/ru101/uc05-finding-venues/finding_venues.py
@@ -61,7 +61,7 @@ isc = {'venue': "Tokyo Tatsumi International Swimming Center",
 def create_venue(venue):
   """Create key and geo entry for passed venue"""
   key = keynamehelper.create_key_name("geo", "venues")
-  redis.geoadd(key, venue['geo']['long'], venue['geo']['lat'], venue['venue'])
+  redis.geoadd(key, (venue['geo']['long'], venue['geo']['lat'], venue['venue']))
 
 def test_venue_search():
   """Test 1 - geo searches around a venue"""
@@ -88,7 +88,7 @@ def create_event_locations(venue):
   for i in range(len(venue['events'])):
     event, _ = venue['events'][i]
     key = keynamehelper.create_key_name("geo", "events", event)
-    p.geoadd(key, venue['geo']['long'], venue['geo']['lat'], venue['venue'])
+    p.geoadd(key, (venue['geo']['long'], venue['geo']['lat'], venue['venue']))
   p.execute()
 
 def test_event_search():
@@ -112,7 +112,7 @@ def create_event_transit_locations(venue):
   for i in range(len(venue['transit'])):
     key = keynamehelper.create_key_name("geo", "transits",
                                         venue['transit'][i])
-    p.geoadd(key, venue['geo']['long'], venue['geo']['lat'], venue['venue'])
+    p.geoadd(key, (venue['geo']['long'], venue['geo']['lat'], venue['venue']))
   p.execute()
 
 def test_transit_search():

--- a/redisu/ru101/uc06-inventory-with-lua/inventory-lua.py
+++ b/redisu/ru101/uc06-inventory-with-lua/inventory-lua.py
@@ -209,7 +209,7 @@ class TestLuaScripts(unittest.TestCase):
         keys = []
         for cust in cust_array:
             c_key = keynamehelper.create_key_name("customer", cust['id'])
-            self.redis.hmset(c_key, cust)
+            self.redis.hset(c_key, mapping = cust)
             keys.append(c_key)
         return keys
 
@@ -225,7 +225,7 @@ class TestLuaScripts(unittest.TestCase):
             if price != None:
                 event['price:' + tier] = price
             e_key = keynamehelper.create_key_name("event", event['sku'])
-            self.redis.hmset(e_key, event)
+            self.redis.hset(e_key, mapping = event)
             self.redis.sadd(e_set_key, event['sku'])
             keys.append(e_key)
         return keys
@@ -237,7 +237,7 @@ class TestLuaScripts(unittest.TestCase):
                     'customer_id': customer['id'], 'qty': quantity,
                     'cost':     quantity * float(event['price:General']),
                     'event_sku': event['sku'], 'ts': int(time.time())}
-        self.redis.hmset(purchase_key, purchase)
+        self.redis.hset(purchase_key, mapping = purchase)
         return purchase_key
 
     def creditcard_auth(self, customer, order_total):

--- a/redisu/utils/dumpload.py
+++ b/redisu/utils/dumpload.py
@@ -74,7 +74,6 @@ def load(redis, filename="/data/ru101.json", compress=False):
       p.delete(obj['k'])
       if obj['t'] == "hash":
         # Needs to be hset but where's the key here?
-        print(f"k {obj['k']} -> v {obj['v']}")
         p.hset(obj['k'], mapping = obj['v'])
       elif obj['t'] == "set":
         for j in range(len(obj['v'])):

--- a/redisu/utils/dumpload.py
+++ b/redisu/utils/dumpload.py
@@ -73,7 +73,9 @@ def load(redis, filename="/data/ru101.json", compress=False):
       obj = json.loads(line)
       p.delete(obj['k'])
       if obj['t'] == "hash":
-        p.hmset(obj['k'], obj['v'])
+        # Needs to be hset but where's the key here?
+        print(f"k {obj['k']} -> v {obj['v']}")
+        p.hset(obj['k'], mapping = obj['v'])
       elif obj['t'] == "set":
         for j in range(len(obj['v'])):
           p.sadd(obj['k'], obj['v'][j])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Faker==4.14.2
 python-dateutil==2.8.1
-redis==3.0.1
+redis==5.0.1
 six==1.15.0
 text-unidecode==1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Faker==4.14.2
-python-dateutil==2.8.1
+python-dateutil==2.8.2
 redis==5.0.1
-six==1.15.0
 text-unidecode==1.3


### PR DESCRIPTION
Upgraded the codebase to redis-py 5.0.1 to remove dependencies that were causing issues with Python 3.12 (see #16 ).

I've also removed subsequent deprecation warnings.

This has been tested on a Mac using Python 3.12.0rc2.  

It needs to be re-tested with another version of Python (try 3.10?).